### PR TITLE
fix: extract file name instead of path

### DIFF
--- a/internal/code.go
+++ b/internal/code.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 )
@@ -20,10 +21,9 @@ func ExtractCodeData() (string, int, string) {
 		name = fnName[strings.LastIndex(fnName, ".")+1:]
 	}
 
-	wd, _ := os.Getwd()
-	relPath := strings.TrimPrefix(strings.TrimPrefix(file, wd), "/")
+	fileName := filepath.Base(file)
 
-	return relPath, line, name
+	return fileName, line, name
 }
 
 func ExtractCodeDataRecursive() (string, int, string) {


### PR DESCRIPTION
# User description
- current approach is sadly not reliable and a different way, probably on compile time, has to be found to find the correct file path and not just the file name

---

# Generated description

Dear maintainer, below is a concise technical summary of the changes proposed in this PR:
<p>Refactor <code>ExtractCodeData</code> to return only the file name using <code>filepath.Base</code> instead of the full path, improving reliability by removing dependency on the working directory.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://main.baz.ninja/changes/baz-scm/falken-trace-go/5?tool=ast&topic=File+Name+Extraction>File Name Extraction</a>
        </td><td>Refactor <code>ExtractCodeData</code> to return only the file name using <code>filepath.Base</code> instead of the full path, improving reliability by removing dependency on the working directory.<details><summary>Modified files (1)</summary><ul><li>internal/code.go</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>Email</th><th>Commit</th><th>Date</th></tr><tr><td>anton.gruebel@gmail.com</td><td>feat-prepare-first-rel...</td><td>October 11, 2024</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @gruebel and the rest of your team on <a href=https://baz.co/login>(Baz)</a>.
    