### PR TITLE
ci: upgrade golangci-lint to v2

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,9 +35,9 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.61
+          version: v2.0
 
   test:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,16 @@
 # https://golangci-lint.run/usage/configuration/#config-file
 version: "2"
-exclusions: &common_exclusions
-  generated: lax
-  paths:
-    - third_party$
-    - builtin$
-    - examples$
-
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - goimports
+  exclusions: &common_exclusions
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 linters:
   enable:
     - errorlint
@@ -20,9 +24,3 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
-formatters:
-  enable:
-    - gci
-    - gofmt
-    - goimports
-  exclusions: *common_exclusions

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,12 @@
 # https://golangci-lint.run/usage/configuration/#config-file
 version: "2"
+exclusions: &common_exclusions
+  generated: lax
+  paths:
+    - third_party$
+    - builtin$
+    - examples$
+
 linters:
   enable:
     - errorlint
@@ -7,24 +14,15 @@ linters:
     - nilerr
     - nolintlint
   exclusions:
-    generated: lax
+    <<: *common_exclusions
     presets:
       - comments
       - common-false-positives
       - legacy
       - std-error-handling
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
 formatters:
   enable:
     - gci
     - gofmt
     - goimports
-  exclusions:
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+  exclusions: *common_exclusions

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,30 @@
 # https://golangci-lint.run/usage/configuration/#config-file
+version: "2"
 linters:
   enable:
     - errorlint
-    - gci
-    - gofmt
-    - goimports
     - gosec
     - nilerr
     - nolintlint
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Upgrades golangci-lint to version 2 in the CI pipeline. Updates the GitHub Actions workflow to use the latest golangci-lint-action and adjusts the golangci-lint configuration file to comply with the new version's requirements.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://main.baz.ninja/changes/baz-scm/falken-trace-go/8?tool=ast&topic=Workflow+Update>Workflow Update</a>
        </td><td>Upgrades golangci-lint-action and version in the GitHub Actions workflow<details><summary>Modified files (1)</summary><ul><li>.github/workflows/pr.yml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>gruebel</td><td>feat-support-OTel-spans-3</td><td>October 13, 2024</td></tr></table></details></td></tr>
<tr><td><a href=https://main.baz.ninja/changes/baz-scm/falken-trace-go/8?tool=ast&topic=Lint+Configuration>Lint Configuration</a>
        </td><td>Updates golangci-lint configuration to align with version 2 requirements<details><summary>Modified files (1)</summary><ul><li>.golangci.yml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>gruebel</td><td>initial-commit</td><td>October 10, 2024</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Join @gruebel and the rest of your team on <a href=https://main.baz.ninja/changes/baz-scm/falken-trace-go/8?tool=ast>(Baz)</a>.
    